### PR TITLE
Fixed the error "undefined method `docs' for nil:NilClass"

### DIFF
--- a/_plugins/obsidian_images_generator.rb
+++ b/_plugins/obsidian_images_generator.rb
@@ -3,8 +3,8 @@ class WikiImages < Jekyll::Generator
   def generate(site)
 
     all_notes = site.collections['notes'].docs
-    all_pages = site.collections['pages'].docs
-
+    all_pages = site.pages
+    
     all_docs = all_notes + all_pages
 
     all_docs.each do |current_note|


### PR DESCRIPTION
When I used your obsidian image plugin, I got the error seen below. I compared your plugin to the existing bidirectional_links_generator plugin and noticed there was a difference in how the pages were being initialized. After I changed the initialization of `all_pages`, the plugin started working. 

```
D:/DocsWeb/_plugins/obsidian_images_generator.rb:6:in `generate': undefined method `docs' for nil:NilClass (NoMethodError)

    all_pages = site.collections['pages'].docs
                                         ^^^^^
        from C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/jekyll-4.3.2/lib/jekyll/site.rb:193:in `block in generate'
        from C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/jekyll-4.3.2/lib/jekyll/site.rb:191:in `each'
        from C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/jekyll-4.3.2/lib/jekyll/site.rb:191:in `generate'
        from C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/jekyll-4.3.2/lib/jekyll/site.rb:79:in `process'
        from C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/jekyll-4.3.2/lib/jekyll/command.rb:28:in `process_site'
        from C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/jekyll-4.3.2/lib/jekyll/commands/build.rb:65:in `build'
        from C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/jekyll-4.3.2/lib/jekyll/commands/build.rb:36:in `process'
        from C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/jekyll-4.3.2/lib/jekyll/command.rb:91:in `block in process_with_graceful_fail'
        from C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/jekyll-4.3.2/lib/jekyll/command.rb:91:in `each'
        from C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/jekyll-4.3.2/lib/jekyll/command.rb:91:in `process_with_graceful_fail'
        from C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/jekyll-4.3.2/lib/jekyll/commands/build.rb:18:in `block (2 levels) in init_with_program'
        from C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/mercenary-0.4.0/lib/mercenary/command.rb:221:in `block in execute'
        from C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/mercenary-0.4.0/lib/mercenary/command.rb:221:in `each'
        from C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/mercenary-0.4.0/lib/mercenary/command.rb:221:in `execute'
        from C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/mercenary-0.4.0/lib/mercenary/program.rb:44:in `go'
        from C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/mercenary-0.4.0/lib/mercenary.rb:21:in `program'
        from C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/jekyll-4.3.2/exe/jekyll:15:in `<top (required)>'
        from C:/Ruby31-x64/bin/jekyll:25:in `load'
        from C:/Ruby31-x64/bin/jekyll:25:in `<main>'
```